### PR TITLE
fix: add a build command in the publish cicd

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 12
-      - run: npm ci
+      - run: npm ci && npm run build
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
       - run: GITHUB_TOKEN=$GITHUB_TOKEN  node scripts/update-version.js
       - uses: EndBug/add-and-commit@v8.0.2


### PR DESCRIPTION
Fixes a bug in the Publish CICD that causes it to publish a broken version to NPM